### PR TITLE
Added {errorcode,issorted}.grc erroneous grace programs

### DIFF
--- a/grace/programs-erroneous/errorcode.grc
+++ b/grace/programs-erroneous/errorcode.grc
@@ -1,0 +1,30 @@
+$$
+  In this erroneous grace program the main function has a return type of not
+  nothing.
+
+  The main function 'errorCode' prints a character array and returns 0 when no
+  errors occur and 1 when segmentation fault happens.
+$$
+
+fun errorCode() : int
+  var carr : char[10];
+  var i, size : int;
+
+{ $errorCode
+  size <- 10;
+  i <- 0;
+  while i < 10 do {
+    if i >= size then {
+      writeString(" Segmentation fault!\n");
+      return 1;
+    }
+    else {
+      if i # 0 then
+        writeChar(' ');
+      writeChar(carr[i]);
+    }
+    i <- i + 1;
+  }
+
+  return 0;
+}

--- a/grace/programs-erroneous/issorted.grc
+++ b/grace/programs-erroneous/issorted.grc
@@ -1,0 +1,24 @@
+$$
+  In this erroneous grace program the main function takes arguments.
+  It is not permitted for the main function to take arguments.
+
+  The main function 'isSorted' takes two arguments, an array and the array's size.
+$$
+
+fun isSorted(ref a : int[]; size : int) : nothing
+  var i, result : int;
+
+{ $ isSorted
+
+  result <- 1;
+  i <- 0;
+  while i < size - 2 do {
+    if a[i] > a[i+1] then
+      result <- 0;
+    i <- i + 1;
+  }
+
+  writeString("The given array is ");
+  if result = 1 then writeString("sorted.\n");
+  else writeString("not sorted.\n");
+}


### PR DESCRIPTION
These two grace programs contain one specific error each.
The 'errorcode.grc' program contains a main function that has a return type of int, and not nothing,
and the 'issorted.grc' program contains a main function that takes two arguments, which is not permitted.