### PR TITLE
Bugfix: arrays.grc had an array dimension mismatch error

### DIFF
--- a/grace/programs/arrays.grc
+++ b/grace/programs/arrays.grc
@@ -8,7 +8,7 @@ $$
 fun main () : nothing
 
   var foo : int[11];
-  var bar : char[2][5][17];
+  var bar : char[2][5][13];
   var zen : int[5][10];
 
     fun arrayProc (ref x : int[]; ref y : char[][5][13]; ref z : int[][10]) : nothing

--- a/grace/programs/arrays.grc
+++ b/grace/programs/arrays.grc
@@ -8,7 +8,7 @@ $$
 fun main () : nothing
 
   var foo : int[11];
-  var bar : char[2][4][17];
+  var bar : char[2][5][17];
   var zen : int[5][10];
 
     fun arrayProc (ref x : int[]; ref y : char[][5][13]; ref z : int[][10]) : nothing


### PR DESCRIPTION
This declaration:
https://github.com/kostis/ntua_compilers/blob/cdaa96a40805089f4a54afba76db5e2aab85dddf/grace/programs/arrays.grc#L11
And this declaration:
https://github.com/kostis/ntua_compilers/blob/cdaa96a40805089f4a54afba76db5e2aab85dddf/grace/programs/arrays.grc#L14
Create an error in this function call:
https://github.com/kostis/ntua_compilers/blob/cdaa96a40805089f4a54afba76db5e2aab85dddf/grace/programs/arrays.grc#L88
The updated declaration does not otherwise change the behavior of the program.