### PR TITLE
Test program fix

### DIFF
--- a/grace/programs/arrays.grc
+++ b/grace/programs/arrays.grc
@@ -30,11 +30,16 @@ fun main () : nothing
         i <- 0;
         j <- 0;
         k <- 0;
-        while i < 2 do
-          while j < 10 do
-            while k < 13 do
+        while i < 2 do {
+          while j < 10 do {
+            while k < 13 do {
               b[i][j][k] <- chr((i + j + k) mod 26 + ascii('A'));
-
+              k <- k + 1;
+              }
+            j <- j + 1;
+            }
+          i <- i + 1;
+        }
         return 0;
       }
 
@@ -67,7 +72,7 @@ fun main () : nothing
       j <- 0;
       s <- 10;
       while i < 10 do {
-        while (z[j][i] # 0) do {
+        while (j < 5 and z[j][i] # 0) do {
           z[j][i] <- a[i];
           j <- j + 1;
         }
@@ -77,11 +82,17 @@ fun main () : nothing
       i <- 0;
       j <- 0;
       k <- 0;
-      while i < 2 do
-        while j < 4 do
-          while k < 13 do
+      while i < 2 do {
+        while j < 4 do {
+          while k < 1 do {
             if ascii(b[i][j][k]) >= 65 then
               y[i][j][k] <- b[i][j][k];
+            k <- k + 1;
+          }
+          j <- j + 1;
+        }
+        i <- i + 1;
+      }
     }
 
 { $ main

--- a/grace/programs/arrays.grc
+++ b/grace/programs/arrays.grc
@@ -84,7 +84,7 @@ fun main () : nothing
       k <- 0;
       while i < 2 do {
         while j < 4 do {
-          while k < 1 do {
+          while k < 13 do {
             if ascii(b[i][j][k]) >= 65 then
               y[i][j][k] <- b[i][j][k];
             k <- k + 1;


### PR DESCRIPTION
Updated arrays.grc.
Previously it would create an infinite loop (while loop variable was not being incremented).
Also it would create a segmentation fault due to accessing unallocated memory address.
Here `z[][10]` was a function argument, an array of undetermined size, but an array of size [5][10] was passed as argument.
```
while (j < 5 and z[j][i] # 0) do {
  z[j][i] <- a[i];
  j <- j + 1;
}
```