### PR TITLE
Move variable definitions to <local-def>

### DIFF
--- a/dana/programs/linemarket.dana
+++ b/dana/programs/linemarket.dana
@@ -99,11 +99,11 @@ def main
 
 
     if stores > MAX_STORES or stores < 1:
-        writeString: "Wrong starting input, let's try again!\n"
+        writeString: "Wrong starting input, let\'s try again!\n"
         stores := readInteger()
 
     if N > MAX_PLACES or N < 1:
-        writeString: "Wrong starting input, let's try again!\n"
+        writeString: "Wrong starting input, let\'s try again!\n"
         N := readInteger()
 
     i := 0

--- a/dana/programs/powint.dana
+++ b/dana/programs/powint.dana
@@ -1,9 +1,9 @@
 def main
 
   def powint: base as int, exp as int, mod as int, result as ref int
+    var temp is int
 
     base := base % mod
-    var temp is int
 
     if exp < 1:
       result := 1

--- a/dana/programs/primeFactors.dana
+++ b/dana/programs/primeFactors.dana
@@ -1,6 +1,8 @@
 def main
   # Helper procedure: prints the prime factors of n
   def primeFactors: n as int
+    var i is int
+    
     # Divide out all factors of 2
     loop:
       if n % 2 = 0:
@@ -8,7 +10,6 @@ def main
         n := n / 2
       else: break
 
-    var i is int
     i := 3
     # Loop over odd numbers starting from 3 while i*i <= n
     loop:


### PR DESCRIPTION
Refactors the placement of `var` definitions in function bodies so they appear in the `<local-def>` section at the top of the function, rather than inside the `<block>` of statements.
