### PR TITLE
Fix semantic rules for forward references in local functions

### DIFF
--- a/dana/programs/binarysearch.dana
+++ b/dana/programs/binarysearch.dana
@@ -1,4 +1,9 @@
 def main
+    def swap: a as ref int, b as ref int
+        var t is int
+        t := a
+        a := b
+        b := t
 
     def partition is int: arr as int [], low high as int
         var pivot i j is int
@@ -20,12 +25,6 @@ def main
             pi := partition(arr, low, high)
             quicksort: arr, low, (pi - 1)
             quicksort: arr, (pi + 1), high  
-    
-    def swap: a as ref int, b as ref int
-        var t is int
-        t := a
-        a := b
-        b := t
 
     def binarySearch is int: arr as int [], low high x as int
         var mid is int 

--- a/dana/programs/bsort.dana
+++ b/dana/programs/bsort.dana
@@ -1,4 +1,9 @@
 def main
+  def swap: x y as ref int
+    var t is int
+    t := x
+    x := y
+    y := t
 
   def bsort: n as int, x as int []
     var changed is byte
@@ -17,12 +22,6 @@ def main
           break : inner_loop_label
       if not changed:
         break : outer_loop_label
-
-  def swap: x y as ref int
-    var t is int
-    t := x
-    x := y
-    y := t
 
   def writeArray: msg as byte [], n as int, x as int []
     var i is int


### PR DESCRIPTION
 **Forward declaration enforcement for local functions**
   - Dana's specification (§1.3.2 – Δομικές μονάδες) states that if a local function calls another local function defined later in the same scope, that called function must either be defined earlier or declared beforehand using decl.
   - In our case, we applied the first option: we reordered the local function definitions so that any function is defined before it is used.

 Therefore, in the Dana programs, we moved the definition of the `swap` function **above** other functions (such as `quicksort`) that call it. 
