### PR TITLE
Fix EOF handling in calculator.dana main loop

### DIFF
--- a/dana/programs/calculator.dana
+++ b/dana/programs/calculator.dana
@@ -46,6 +46,7 @@ def main
     var op is byte
 
     loop lines:
+        buf[0] := '\0'
         readString: 256, buf
 
         # Stop if we got nothing


### PR DESCRIPTION
This change adds a single line at the start of the lines loop in `calculator.dana`:
```
buf[0] := '\0'
```
This ensures the buffer is always null-terminated before reading new input.
When readString reaches EOF without writing anything, strlen(buf) now returns 0 instead of reading stale data from previous iterations.

### Why it was necessary:
Without clearing the buffer, when having an input file for ./a.out < calculator.input the loop would be infinite. This fix guarantees that the loop terminates cleanly at EOF.