### PR TITLE
[Dana] Fix out of bounds integers in `linemarket`

### DIFF
--- a/dana/programs/linemarket.dana
+++ b/dana/programs/linemarket.dana
@@ -17,7 +17,7 @@ def main
     var stores size s f N tail is int
     var MAX_STORES MAX_PLACES is int
     var i is int
-    var arr is int[200000]
+    var arr is int[32767]
 
     def swap: x y as ref int
         var t is int
@@ -45,7 +45,7 @@ def main
         var last_position placed_stores i_ps is int
         var j is int
         var position is int
-        last_position := -1000000000
+        last_position := -32768
         placed_stores := 0
         i_ps := 0
         loop:
@@ -91,8 +91,8 @@ def main
         return: result
 
     tail := 0
-    MAX_STORES := 1000000
-    MAX_PLACES := 100000
+    MAX_STORES := 32767
+    MAX_PLACES := 32767
 
     stores := readInteger()
     N := readInteger()


### PR DESCRIPTION
Max int is 32767, min int is -32768