### PR TITLE
[PCL] Added programs with semantic errors

### DIFF
--- a/pcl/programs-erroneous/semantic_error_1.pcl
+++ b/pcl/programs-erroneous/semantic_error_1.pcl
@@ -1,0 +1,9 @@
+program sem_error_arg_type_mismatch;
+(* Error: Argument type mismatch: boolean passed where integer is expected *)
+function add(a, b : integer) : integer;
+begin
+    result := a + b
+end;
+begin
+    writeInteger(add(1, true))
+end.

--- a/pcl/programs-erroneous/semantic_error_10.pcl
+++ b/pcl/programs-erroneous/semantic_error_10.pcl
@@ -1,0 +1,10 @@
+program sem_error_scope_inner_var;
+(* Error: Variable 'x' is declared in an inner scope and is not accessible in the outer scope *)
+procedure foo();
+    var x : integer;
+begin
+    x := 42
+end;
+begin
+    x := 10
+end.

--- a/pcl/programs-erroneous/semantic_error_11.pcl
+++ b/pcl/programs-erroneous/semantic_error_11.pcl
@@ -1,0 +1,6 @@
+program sem_error_type_mismatch;
+(* Error: Type mismatch: boolean value assigned to integer variable *)
+var x : integer;
+begin
+    x := true
+end.

--- a/pcl/programs-erroneous/semantic_error_12.pcl
+++ b/pcl/programs-erroneous/semantic_error_12.pcl
@@ -1,0 +1,6 @@
+program sem_error_unary_minus_bool;
+(* Error: Unary minus (-) cannot be applied to boolean type *)
+var x : boolean;
+begin
+    x := -true
+end.

--- a/pcl/programs-erroneous/semantic_error_13.pcl
+++ b/pcl/programs-erroneous/semantic_error_13.pcl
@@ -1,0 +1,5 @@
+program sem_error_undeclared;
+(* Error: Use of undeclared variable 'x' *)
+begin
+    x := 42
+end.

--- a/pcl/programs-erroneous/semantic_error_14.pcl
+++ b/pcl/programs-erroneous/semantic_error_14.pcl
@@ -1,0 +1,8 @@
+program sem_error_while_not_bool;
+(* Error: 'while' condition must be boolean; integer expression given *)
+var i : integer;
+begin
+    i := 10;
+    while i do
+        i := i - 1
+end.

--- a/pcl/programs-erroneous/semantic_error_15.pcl
+++ b/pcl/programs-erroneous/semantic_error_15.pcl
@@ -1,0 +1,9 @@
+program sem_error_wrong_args;
+(* Error: Wrong number of arguments: function 'foo' expects 1 argument but 2 were given *)
+function foo(x : integer) : integer;
+begin
+    result := x + 1
+end;
+begin
+    writeInteger(foo(1, 2))
+end.

--- a/pcl/programs-erroneous/semantic_error_2.pcl
+++ b/pcl/programs-erroneous/semantic_error_2.pcl
@@ -1,0 +1,7 @@
+program sem_error_call_var_as_func;
+(* Error: Variable 'x' is not a function and cannot be called with () *)
+var x : integer;
+begin
+    x := 5;
+    writeInteger(x())
+end.

--- a/pcl/programs-erroneous/semantic_error_3.pcl
+++ b/pcl/programs-erroneous/semantic_error_3.pcl
@@ -1,0 +1,10 @@
+program sem_error_compare_diff_types;
+(* Error: Cannot compare values of different types (integer and boolean) *)
+var x : integer;
+var y : boolean;
+begin
+    x := 5;
+    y := true;
+    if x = y then
+        writeString("wrong\n")
+end.

--- a/pcl/programs-erroneous/semantic_error_4.pcl
+++ b/pcl/programs-erroneous/semantic_error_4.pcl
@@ -1,0 +1,7 @@
+program sem_error_duplicate_var;
+(* Error: Duplicate variable declaration: 'x' is declared more than once *)
+var x : integer;
+var x : integer;
+begin
+    x := 1
+end.

--- a/pcl/programs-erroneous/semantic_error_5.pcl
+++ b/pcl/programs-erroneous/semantic_error_5.pcl
@@ -1,0 +1,6 @@
+program sem_error_index_not_int;
+(* Error: Array index must be an integer; boolean value used as index *)
+var a : array [10] of integer;
+begin
+    a[true] := 5
+end.

--- a/pcl/programs-erroneous/semantic_error_6.pcl
+++ b/pcl/programs-erroneous/semantic_error_6.pcl
@@ -1,0 +1,7 @@
+program sem_error_label_duplicate_def;
+(* Error: Label 'done' is defined more than once in the same block *)
+label done;
+begin
+    done : writeString("first\n");
+    done : writeString("second\n")
+end.

--- a/pcl/programs-erroneous/semantic_error_7.pcl
+++ b/pcl/programs-erroneous/semantic_error_7.pcl
@@ -1,0 +1,7 @@
+program sem_error_label_not_declared;
+(* Error: 'goto' references label 'done' that has not been declared *)
+begin
+    goto done;
+    writeString("never\n");
+    done : writeString("end\n")
+end.

--- a/pcl/programs-erroneous/semantic_error_8.pcl
+++ b/pcl/programs-erroneous/semantic_error_8.pcl
@@ -1,0 +1,6 @@
+program sem_error_real_to_int;
+(* Error: Type mismatch: cannot assign a real literal to an integer variable *)
+var x : integer;
+begin
+    x := 3.14
+end.

--- a/pcl/programs-erroneous/semantic_error_9.pcl
+++ b/pcl/programs-erroneous/semantic_error_9.pcl
@@ -1,0 +1,6 @@
+program sem_error_relational_bool;
+(* Error: Relational operator < cannot be applied to boolean operands *)
+begin
+    if true < false then
+        writeString("wrong\n")
+end.


### PR DESCRIPTION
- Added 15 simple PCL programs with semantic errors.
- All programs are syntactically correct (they pass the parser) but contain exactly one semantic error each.
- Each file includes a comment explaining the specific semantic rule being violated to assist with debugging and verification.


