### PR TITLE
PCL: Add some semantically erroroneous programs

### DIFF
--- a/pcl/programs-erroneous/semantic_error_16.pcl
+++ b/pcl/programs-erroneous/semantic_error_16.pcl
@@ -1,0 +1,14 @@
+program sem_error_illegal_cross_scope_jump;
+(* Error: Illegal cross-scope jump: label declared in the main block but used by goto inside a nested procedure *)
+
+label outside;
+
+procedure inner();
+begin
+    goto outside
+end;
+
+begin
+    inner();
+    outside : writeString("outside")
+end.

--- a/pcl/programs-erroneous/semantic_error_17.pcl
+++ b/pcl/programs-erroneous/semantic_error_17.pcl
@@ -1,0 +1,9 @@
+program sem_error_goto_label_not_defined;
+(* Error: 'goto' targets a label that is declared but never defined in any body *)
+
+label missing;
+
+begin
+    goto missing;
+    writeString("error")
+end.

--- a/pcl/programs-erroneous/semantic_error_18.pcl
+++ b/pcl/programs-erroneous/semantic_error_18.pcl
@@ -1,0 +1,11 @@
+program sem_error_result_in_procedure;
+(* Error: 'result' is used inside a procedure (procedures do not return values) *)
+
+procedure p();
+begin
+    result := 1
+end;
+
+begin
+    p()
+end.

--- a/pcl/programs-erroneous/semantic_error_19.pcl
+++ b/pcl/programs-erroneous/semantic_error_19.pcl
@@ -1,0 +1,6 @@
+program sem_error_result_in_main;
+(* Error: 'result' is used in the main program body (result exists only inside functions) *)
+
+begin
+    result := 1
+end.

--- a/pcl/programs-erroneous/semantic_error_20.pcl
+++ b/pcl/programs-erroneous/semantic_error_20.pcl
@@ -1,0 +1,13 @@
+program sem_error_forward_function_mismatch;
+(* Error: Forward function declaration is not consistent with the later definition *)
+
+forward function foo(x : integer) : integer;
+
+function foo(x : integer; y : integer) : integer;
+begin
+    result := x + y
+end;
+
+begin
+    writeString("error")
+end.

--- a/pcl/programs-erroneous/semantic_error_21.pcl
+++ b/pcl/programs-erroneous/semantic_error_21.pcl
@@ -1,0 +1,13 @@
+program sem_error_assignment_from_procedure_call;
+(* Error: No assignment from procedure calls (only functions can return values) *)
+
+var x : integer;
+
+procedure p();
+begin
+    writeString("hello")
+end;
+
+begin
+    x := p()
+end.

--- a/pcl/programs-erroneous/semantic_error_22.pcl
+++ b/pcl/programs-erroneous/semantic_error_22.pcl
@@ -1,0 +1,5 @@
+program sem_error_deref_nil;
+(* Error: Dereferencing nil *)
+begin
+    writeInteger(nil^)
+end.

--- a/pcl/programs-erroneous/semantic_error_23.pcl
+++ b/pcl/programs-erroneous/semantic_error_23.pcl
@@ -1,0 +1,11 @@
+program sem_error_var_param_requires_lvalue_const;
+(* Error: 'var' (by reference) parameter requires an lvalue; constant passed *)
+
+procedure inc(var x : integer);
+begin
+    x := x + 1
+end;
+
+begin
+    inc(1)
+end.

--- a/pcl/programs-erroneous/semantic_error_24.pcl
+++ b/pcl/programs-erroneous/semantic_error_24.pcl
@@ -1,0 +1,14 @@
+program sem_error_var_param_requires_lvalue_expr;
+(* Error: 'var' (by reference) parameter requires an lvalue; expression passed *)
+
+var a : integer;
+
+procedure inc(var x : integer);
+begin
+    x := x + 1
+end;
+
+begin
+    a := 10;
+    inc(a + 1)
+end.


### PR DESCRIPTION
Adds a few more semantically erroneous programs that are grammatically correct. Follows the structure and naming of other examples (`semantic_error_<i>.pcl`)
### Coverage
Labels:
- Illegal cross scope `goto`
- `goto` to a declared but undefined label

Functions & Procedures:
- Usage of `result` keyword in non-function blocks
- Inconsistency between `forward` and actual header declarations
- Assignment from a procedure call
- Passing a constant or expression to a `var` argument (l-value expected)

Misc:
- Dereference of `nil`