### PR TITLE
[PCL] Add test for out-of-bounds/very large integer literals

### DIFF
--- a/pcl/programs-erroneous/semantic_error_26.pcl
+++ b/pcl/programs-erroneous/semantic_error_26.pcl
@@ -1,0 +1,9 @@
+program sem_error_integer_literal_oob;
+    (* Error: Integer constant is out-of-bounds for 32-bit or 64-bit integer. *)
+    (* Valid 32-bit signed integer range is -2,147,483,648 to 2,147,483,647 *)
+    (* Valid 64-bit signed integer range is -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807 *)
+    (* However, this program is perfectly semantically valid if integer is implemented as BigInt, or as a 459+ bit integer *)
+    var a : integer;
+begin
+    a := 676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767676767
+end.


### PR DESCRIPTION
The test has an integer literal which, while lexically correct, is too big to fit in a 32-bit or 64-bit integer, which is likely what most implementations of pcl use.

The pcl spec specifies that `integer` needs to be 4+ bytes with no upper limit, so someone brave enough could opt to implement it as a BigInt or a huge integer. In that case, the program is semantically valid, but still serves as a test that the compiler can properly handle enormous literals. Lexing these literals in the first place needs some care, because library functions like C's `atoi` or C++'s `std::from_chars` will throw a runtime exception or return an error if passed such a literal.

For reference, ceil(log2(a)) = 458, so a signed integer would need to be at least 459 bits wide to store the value.